### PR TITLE
Use #data_source_exists? over #table_exists? to prevent deprecation warning

### DIFF
--- a/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb
+++ b/lib/postgres_ext/active_record/5.0/relation/predicate_builder/array_handler.rb
@@ -1,0 +1,38 @@
+require 'active_record/relation/predicate_builder'
+require 'active_record/relation/predicate_builder/array_handler'
+
+require 'active_support/concern'
+
+module ActiveRecord
+  class PredicateBuilder
+    module ArrayHandlerPatch
+      extend ActiveSupport::Concern
+
+      included do
+        def call_with_feature(attribute, value)
+          column = case attribute.try(:relation)
+                   when Arel::Nodes::TableAlias, NilClass
+                   else
+                     cache = ActiveRecord::Base.connection.schema_cache
+                     if cache.data_source_exists? attribute.relation.name
+                       cache.columns(attribute.relation.name).detect{ |col| col.name.to_s == attribute.name.to_s }
+                     end
+                   end
+          if column && column.respond_to?(:array) && column.array
+            attribute.eq(value)
+          else
+            call_without_feature(attribute, value)
+          end
+        end
+
+        alias_method_chain(:call, :feature)
+      end
+
+      module ClassMethods
+
+      end
+    end
+  end
+end
+
+ActiveRecord::PredicateBuilder::ArrayHandler.send(:include, ActiveRecord::PredicateBuilder::ArrayHandlerPatch)

--- a/lib/postgres_ext/active_record/relation.rb
+++ b/lib/postgres_ext/active_record/relation.rb
@@ -1,10 +1,15 @@
-gdep = Gem::Dependency.new('activerecord', '>= 4.2.0')
-ar_version_cutoff = gdep.matching_specs.sort_by(&:version).last
+gdep_4_2 = Gem::Dependency.new('activerecord', '>= 4.2.0')
+ar_4_2_version_cutoff = gdep_4_2.matching_specs.sort_by(&:version).last
+
+gdep_5_0 = Gem::Dependency.new('activerecord', '~> 5.0.0')
+ar_5_0_version_cutoff = gdep_5_0.matching_specs.sort_by(&:version).last
 
 require 'postgres_ext/active_record/relation/merger'
 require 'postgres_ext/active_record/relation/query_methods'
 
-if ar_version_cutoff
+if ar_5_0_version_cutoff
+  require 'postgres_ext/active_record/5.0/relation/predicate_builder/array_handler'
+elsif ar_4_2_version_cutuff
   require 'postgres_ext/active_record/relation/predicate_builder/array_handler'
 else
   require 'postgres_ext/active_record/4.x/relation/predicate_builder'

--- a/test/queries/common_table_expression_test.rb
+++ b/test/queries/common_table_expression_test.rb
@@ -61,7 +61,7 @@ describe 'Common Table Expression queries' do
 
   describe '.from_cte(common_table_expression_hash)' do
     it 'generates an expression with the CTE as the main table' do
-      query = Person.from_cte('lucky_number_seven', Person.where(lucky_number: 7)).where(id: 5)
+      query = Person.from_cte('lucky_number_seven', Person.where(lucky_number: 7)).where(lucky_number_seven: { id: 5 })
       query.to_sql.must_match(/WITH "lucky_number_seven" AS \(SELECT "people".* FROM "people"(\s+)WHERE "people"."lucky_number" = 7\) SELECT "lucky_number_seven".* FROM "lucky_number_seven"(\s+)WHERE "lucky_number_seven"."id" = 5/)
     end
 


### PR DESCRIPTION
This prevents the following warning from appearing:

    DEPRECATION WARNING: table_exists? is deprecated and will be removed
    from Rails 5.1 (use #data_source_exists? instead)